### PR TITLE
Update knowledge-beacon-list.yaml

### DIFF
--- a/api/knowledge-beacon-list.yaml
+++ b/api/knowledge-beacon-list.yaml
@@ -14,20 +14,15 @@ beacons:
   description: protein-protein interactions for demo..
   wraps: http://string-db.org/cgi/help.pl?subpage=api
   contact: goodb
-- url:  http://52.14.14.106:8090/api
-  name: Monarch wrapper
-  description: wraps monarch services
-  wraps: https://api.monarchinitiative.org/api/
-  contact: goodb
 - name: Red
   description: Drug-Drug interactions from red team
   status: in_progress
   contact: victorganic
-- name: Monarch Biolink
+- url: https://biolink-kb.ncats.io/
+  name: Monarch Biolink
   description: Wraps Monarch biolink API
   wraps: https://api.monarchinitiative.org/api/
-  status: in_progress
-  contact: lance
+  contact: Lance Hannestad
 - name: Monarch Ontologies
   description: Wraps Monarch SciGraph ontology
   wraps: https://scigraph-ontology.monarchinitiative.org/scigraph/docs/


### PR DESCRIPTION
- Added new Biolink URL
- Deleted reference to Ben Good's previous implementation since the server was down