### PR TITLE
Update knowledge-beacon-list.yaml

### DIFF
--- a/api/knowledge-beacon-list.yaml
+++ b/api/knowledge-beacon-list.yaml
@@ -16,7 +16,7 @@ beacons:
   description: protein-protein interactions for demo..
   wraps: http://string-db.org/cgi/help.pl?subpage=api
   contact: goodb
-  status: deployed
+  status: in_progress
 - name: Red
   description: Drug-Drug interactions from red team
   status: in_progress


### PR DESCRIPTION
Setting beacon `String-db.org wrapper`'s status to `in_progress` because it doesn't yet implement paging and is slowing down the beacon aggregator by returning too much data.