### PR TITLE
Add qualification

### DIFF
--- a/api/knowledge-beacon-api.yaml
+++ b/api/knowledge-beacon-api.yaml
@@ -710,6 +710,37 @@ paths:
                       description: >
                         (Optional) a boolean that if set to true, indicates the
                         edge statement is negated i.e. is not true
+                    qualification:
+                      title: BeaconStatementPredicateQualification
+                      type: object
+                      required: false
+                      properties:
+                        description:
+                          type: string
+                          enum: [inferred, tentitive]
+                          description: >
+                            Either whether we have drawn a failable inference, or the knowledge
+                            source is tentitively reporting the given statement.
+                        explanation:
+                          type: string
+                          description: >
+                            If the qualification is inferred then a detailed explanation of the
+                            assumptions that have gone into our inference, and why this is a good
+                            conclusion to have drawn. If the qualification is tentitive, then
+                            an explanation of the confidence the knowledge source expresses in
+                            the given statement.
+                        unqualified_edge_label:
+                          type: string
+                          description: >
+                            A more general edge label that the given edge label inherits from
+                            that the user can take this statement to entail even if they don't
+                            trust the qualification. For example, if we state that one thing
+                            increases the abundance of another, but qualify that it might
+                            decrease abundance instead, we could say unqualifiedly that the
+                            one affects the abundance of the other. We can thus be confident
+                            that the one affects the abundance of the other, even if we
+                            cannot be confident that the one increases the abundance of the
+                            other.
                 object:
                   title: BeaconStatementObject
                   type: object
@@ -816,13 +847,37 @@ paths:
                 description: >
                   A CURIE prefix, e.g. Pharos, MGI, Monarch. The group that
                   curated/asserted the statement made in an edge.
-              qualifiers:
-                type: array
-                description: >
-                  (Optional) terms representing qualifiers that modify or
-                  qualify the meaning of the statement made in an edge.
-                items:
-                  type: string
+              qualification:
+                      title: BeaconStatementPredicateQualification
+                      type: object
+                      required: false
+                      properties:
+                        description:
+                          type: string
+                          enum: [inferred, tentitive]
+                          description: >
+                            Either whether we have drawn a failable inference, or the knowledge
+                            source is tentitively reporting the given statement.
+                        explanation:
+                          type: string
+                          description: >
+                            If the qualification is inferred then a detailed explanation of the
+                            assumptions that have gone into our inference, and why this is a good
+                            conclusion to have drawn. If the qualification is tentitive, then
+                            an explanation of the confidence the knowledge source expresses in
+                            the given statement.
+                        unqualified_edge_label:
+                          type: string
+                          description: >
+                            A more general edge label that the given edge label inherits from
+                            that the user can take this statement to entail even if they don't
+                            trust the qualification. For example, if we state that one thing
+                            increases the abundance of another, but qualify that it might
+                            decrease abundance instead, we could say unqualifiedly that the
+                            one affects the abundance of the other. We can thus be confident
+                            that the one affects the abundance of the other, even if we
+                            cannot be confident that the one increases the abundance of the
+                            other.
               annotation:
                 type: array
                 description: >


### PR DESCRIPTION
@cmungall @RichardBruskiewich we will need a way to express qualifications in edges. The API already had qualifications in the statement details endpoint, but that's not right since they're not just details--they can drastically change what a statement is saying!

I figure that along with expressing a qualification it would be valuable to give an explanation of the qualification and the assumptions that went into it if it was inferred, and then to give a more generic unqualified statement that would be true even if the qualified statement was false.

For example, in Rhea a reactions equation is typically given with reactants on the left and products on the right. This isn't guaranteed, but it's something we might feel is safe to assume. We can then infer that an enzyme that catalyzes that reaction increases production of those compounds on the right side of the reaction. This of course is something we must say with qualification. But we can also say without qualification that the enzyme affects the production of those compounds on the right side of the reaction. The unqualified statement should always use a more generic form of the predicate that the qualified statement uses.

This is a first attempt, and probably a sloppy one. I welcome suggestions about how qualifications could be better expressed in our API.
https://github.com/NCATS-Tangerine/translator-knowledge-beacon/blob/cf1cd685853bf0a521acd187e91050e769fb25c0/api/knowledge-beacon-api.yaml#L713-L743